### PR TITLE
Changes to the notice page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,10 @@
+<html>
+    <head>
+        <title>Notice</title>
+    </head>
+    <body>
+        Poggit is currently down due to technical issues on the server.
+        As we have no offsite backup,
+        the server cannot be resumed until 2023-03-01.
+    </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <html>
     <head>
-        <title>Redirecting...</title>
+        <!--<title>Redirecting...</title>-->
+        <title>Notice</title>
         <!--<script>window.location.replace("https://poggit.pmmp.io");</script>
         <noscript>
             <meta http-equiv="refresh" content="0; url=https://poggit.pmmp.io">


### PR DESCRIPTION
- The page title has been changed from "Redirecting..." to "Notice".
- Created the `404.html` page to also show the notice page in URLs other than the index (e.g. https://poggit.pmmp.io/p/HideCommands) so it won't show the default GitHub 404 page.

Please let me know if I need to make some revisions to this PR.